### PR TITLE
Add `mixed` return type to `jsonSerialize` method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4.0",
+    "php": ">=8.0.0",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -71,7 +71,7 @@ class Definition implements \JsonSerializable
   public string $hash = ''; // Hash of the definition for change detection, latest hash can be returned in HealthResponse
 
   #[\ReturnTypeWillChange]
-  public function jsonSerialize()
+  public function jsonSerialize(): mixed
   {
     $data = get_object_vars($this);
     if(empty($data['hash']))

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -20,7 +20,7 @@ class Permission implements \JsonSerializable
     return $t;
   }
 
-  public function jsonSerialize()
+  public function jsonSerialize(): mixed
   {
     return array_filter([
       'key'         => $this->key,

--- a/src/PermissionMeta.php
+++ b/src/PermissionMeta.php
@@ -22,7 +22,7 @@ class PermissionMeta implements \JsonSerializable
     return $t;
   }
 
-  public function jsonSerialize()
+  public function jsonSerialize(): mixed
   {
     return array_filter([
       'key'             => $this->key,

--- a/src/PermissionStatement.php
+++ b/src/PermissionStatement.php
@@ -10,7 +10,7 @@ class PermissionStatement implements \JsonSerializable
   public array $meta = [];
 
   #[\ReturnTypeWillChange]
-  public function jsonSerialize()
+  public function jsonSerialize(): mixed
   {
     return [
       'e' => $this->effect ?? PermissionEffect::Allow,


### PR DESCRIPTION
Updates to use PHP 8.0 at minimum and adds `mixed` to `jsonSerialize` method